### PR TITLE
Remove unnecessary configuration flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,17 +8,6 @@
   "license": "MIT",
   "config": {
     "serviceURL": "https://todoist.com/Users/showLogin",
-    "serviceName": "Todoist",
-    "message": "",
-    "popup": [],
-    "hasNotificationSound": false,
-    "hasIndirectMessages": true,
-    "hasTeamID": false,
-    "customURL": false,
-    "hostedOnly": false,
-    "webviewOptions": {
-      "disablewebsecurity": ""
-    },
-    "openDevTools": false
+    "hasIndirectMessages": true
   }
 }


### PR DESCRIPTION
I did a lot of tests to reduce the flag-jungle over the last couple of days. A simple service like todoist doesn't require more than those two config flags:
```json
"config": {
    "serviceURL": "https://todoist.com/Users/showLogin",
    "hasIndirectMessages": true
}
```